### PR TITLE
API update, allow different types of collectibles in a pack, hash pack

### DIFF
--- a/api/misc.http
+++ b/api/misc.http
@@ -16,11 +16,11 @@ content-type: application/json
   },
   "packTemplate":{
     "packReference": {
-      "name": "Pack NFT",
+      "name": "PackNFT",
       "address": "0x2"
     },
     "collectibleReference": {
-      "name": "Collectible NFT",
+      "name": "CollectibleNFT",
       "address": "0x3"
     },
     "packCount":2,

--- a/api/misc.http
+++ b/api/misc.http
@@ -19,17 +19,21 @@ content-type: application/json
       "name": "PackNFT",
       "address": "0x2"
     },
-    "collectibleReference": {
-      "name": "CollectibleNFT",
-      "address": "0x3"
-    },
     "packCount":2,
     "buckets": [
       {
+        "collectibleReference": {
+          "name": "CollectibleNFT",
+          "address": "0x3"
+        },
         "collectibleCount": 3,
         "collectibleCollection": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
       },
       {
+        "collectibleReference": {
+          "name": "CollectibleNFT",
+          "address": "0x3"
+        },
         "collectibleCount": 2,
         "collectibleCollection": [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
       }
@@ -43,14 +47,6 @@ content-type: application/json
 
 ### Get
 GET http://localhost:3000/v1/distributions/{{ distributionId }} HTTP/1.1
-content-type: application/json
-
-### Settle
-PUT http://localhost:3000/v1/distributions/{{ distributionId }}/settle HTTP/1.1
-content-type: application/json
-
-### Confirm
-PUT http://localhost:3000/v1/distributions/{{ distributionId }}/confirm HTTP/1.1
 content-type: application/json
 
 ### Cancel

--- a/models/Bucket.yaml
+++ b/models/Bucket.yaml
@@ -1,7 +1,16 @@
 type: object
 title: Bucket
 description: A bucket from which to pick collectibles into a pack.
+examples:
+  - collectibleCount: 1
+    collectibleCollection:
+      - 1
+      - 2
+      - 3
+      - 4
 properties:
+  collectibleReference:
+    $ref: ./Contract-Reference.yaml
   collectibleCount:
     type: integer
     format: int64
@@ -14,10 +23,3 @@ properties:
       type: integer
       format: int64
       minimum: 1
-examples:
-  - collectibleCount: 1
-    collectibleCollection:
-      - 1
-      - 2
-      - 3
-      - 4

--- a/models/Distribution.yaml
+++ b/models/Distribution.yaml
@@ -35,7 +35,7 @@ properties:
   resolvedCollection:
     type: array
     items:
-      type: integer
-      format: int64
+      type: string
+      example: A.0000000000000003.CollectibleNFT.11
   settlementStatus:
     $ref: ./Settlement-Status.yaml

--- a/models/Pack-Template.yaml
+++ b/models/Pack-Template.yaml
@@ -4,8 +4,6 @@ description: A template from which to generate packs.
 properties:
   packReference:
     $ref: ./Contract-Reference.yaml
-  collectibleReference:
-    $ref: ./Contract-Reference.yaml
   packCount:
     type: integer
     minimum: 1

--- a/service/app/app.go
+++ b/service/app/app.go
@@ -16,20 +16,20 @@ func New(cfg *config.Config, db Store, flowClient *client.Client) *App {
 	return &App{cfg, db, flowClient}
 }
 
-func (app *App) CreateDistribution(distribution Distribution) (string, error) {
+func (app *App) CreateDistribution(distribution Distribution) (uuid.UUID, error) {
 	if err := distribution.Validate(); err != nil {
-		return "", err
+		return uuid.Nil, err
 	}
 
 	if err := distribution.Resolve(); err != nil {
-		return "", err
+		return uuid.Nil, err
 	}
 
 	if err := app.db.InsertDistribution(&distribution); err != nil {
-		return "", err
+		return uuid.Nil, err
 	}
 
-	return distribution.ID.String(), nil
+	return distribution.ID, nil
 }
 
 func (app *App) ListDistributions(limit, offset int) ([]Distribution, error) {

--- a/service/app/distribution.go
+++ b/service/app/distribution.go
@@ -11,7 +11,7 @@ import (
 // Resolve should
 // - validate the distribution
 // - distribute given collectibles into packs based on given template
-// - seal each pack??
+// - hash each pack
 // - set the distributions state to resolved
 func (dist *Distribution) Resolve() error {
 	if dist.State != common.DistributionStateInit {
@@ -55,10 +55,10 @@ func (dist *Distribution) Resolve() error {
 		slotBaseIndex += countPerPack
 	}
 
-	// Sealing each pack
+	// Setting commitment hashes of each pack
 	for i := range packs {
-		if err := packs[i].Seal(); err != nil {
-			return fmt.Errorf("error while sealing pack %d: %w", i+1, err)
+		if err := packs[i].SetCommitmentHash(dist); err != nil {
+			return fmt.Errorf("error while hashing pack %d: %w", i+1, err)
 		}
 	}
 

--- a/service/app/distribution.go
+++ b/service/app/distribution.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"math/rand"
+	"sort"
 	"time"
 
 	"github.com/flow-hydraulics/flow-pds/service/common"
@@ -52,7 +53,7 @@ func (dist *Distribution) Resolve() error {
 
 			collectible := Collectible{
 				ContractReference: bucket.CollectibleReference,
-				FlowId:            bucket.CollectibleCollection[randomIndex],
+				FlowID:            bucket.CollectibleCollection[randomIndex],
 			}
 
 			packs[packIndex].Collectibles[slotIndex] = collectible
@@ -119,8 +120,8 @@ func (dist Distribution) ResolvedCollection() []Collectible {
 	for _, pack := range dist.Packs {
 		res = append(res, pack.Collectibles...)
 	}
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	r.Shuffle(len(res), func(i, j int) { res[i], res[j] = res[j], res[i] })
+	// Sort collection by flowID
+	sort.Sort(CollectibleByFlowID(res))
 	return res
 }
 

--- a/service/app/distribution.go
+++ b/service/app/distribution.go
@@ -28,7 +28,7 @@ func (dist *Distribution) Resolve() error {
 	// Init packs and their slots
 	packs := make([]Pack, packCount)
 	for i := range packs {
-		packs[i].Slots = make([]PackSlot, packSlotCount)
+		packs[i].Slots = make(common.FlowIDList, packSlotCount)
 	}
 
 	// Distributing collectibles
@@ -47,10 +47,9 @@ func (dist *Distribution) Resolve() error {
 		for i := 0; i < countTotal; i++ {
 			randomIndex := permutation[i]
 			collectible := bucket.CollectibleCollection[randomIndex]
-			slot := PackSlot{CollectibleFlowID: collectible}
 			packIndex := i % packCount
 			slotIndex := (i / packCount) + slotBaseIndex
-			packs[packIndex].Slots[slotIndex] = slot
+			packs[packIndex].Slots[slotIndex] = collectible
 		}
 
 		slotBaseIndex += countPerPack
@@ -107,8 +106,8 @@ func (dist *Distribution) Cancel() error {
 	return nil
 }
 
-func (dist Distribution) packSlots() []PackSlot {
-	var slots []PackSlot
+func (dist Distribution) packSlots() common.FlowIDList {
+	var slots common.FlowIDList
 	for _, pack := range dist.Packs {
 		slots = append(slots, pack.Slots...)
 	}
@@ -118,11 +117,7 @@ func (dist Distribution) packSlots() []PackSlot {
 // ResolvedCollection should publicly present what collectibles got in the distribution
 // without revealing in which pack each one resides
 func (dist Distribution) ResolvedCollection() common.FlowIDList {
-	slots := dist.packSlots()
-	res := make([]common.FlowID, len(slots))
-	for i := range slots {
-		res[i] = slots[i].CollectibleFlowID
-	}
+	res := dist.packSlots()
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	r.Shuffle(len(res), func(i, j int) { res[i], res[j] = res[j], res[i] })
 	return res

--- a/service/app/distribution_test.go
+++ b/service/app/distribution_test.go
@@ -99,8 +99,14 @@ func TestDistributionResolution(t *testing.T) {
 	r1 := d.ResolvedCollection()
 	r2 := d.ResolvedCollection()
 
-	if reflect.DeepEqual(r1, r2) {
-		t.Fatalf("resolved collections should not match")
+	if !reflect.DeepEqual(r1, r2) {
+		t.Fatalf("resolved collections should match")
+	}
+
+	for i := range r1 {
+		if i > 0 && r1[i-1].FlowID > r1[i].FlowID {
+			t.Fatal("resolved collection should be sorted ascending by flow id")
+		}
 	}
 
 	if len(d.Packs) != packCount {
@@ -114,7 +120,7 @@ func TestDistributionResolution(t *testing.T) {
 		}
 
 		for _, c := range p.Collectibles {
-			if c.FlowId == common.FlowID(0) {
+			if c.FlowID == common.FlowID(0) {
 				t.Fatalf("did not expect 0 value in a slot")
 			}
 		}

--- a/service/app/distribution_test.go
+++ b/service/app/distribution_test.go
@@ -22,18 +22,28 @@ func TestDistributionValidation(t *testing.T) {
 
 	bucket1 := collection[:20]
 	bucket2 := collection[20:25]
+	collectibleRef := common.AddressLocation{
+		Name:    "TestCollectibleNFT",
+		Address: common.FlowAddress(flow.HexToAddress("0x2")),
+	}
 
 	d := Distribution{
 		DistID: common.FlowID(1),
 		Issuer: common.FlowAddress(flow.HexToAddress("0x1")),
 		PackTemplate: PackTemplate{
+			PackReference: common.AddressLocation{
+				Name:    "TestPackNFT",
+				Address: common.FlowAddress(flow.HexToAddress("0x2")),
+			},
 			PackCount: 3,
 			Buckets: []Bucket{
 				{
+					CollectibleReference:  collectibleRef,
 					CollectibleCount:      10,
 					CollectibleCollection: bucket1,
 				},
 				{
+					CollectibleReference:  collectibleRef,
 					CollectibleCount:      3,
 					CollectibleCollection: bucket2,
 				},
@@ -53,29 +63,31 @@ func TestDistributionResolution(t *testing.T) {
 
 	bucket1 := collection[:80]
 	bucket2 := collection[80:100]
+	collectibleRef := common.AddressLocation{
+		Name:    "TestCollectibleNFT",
+		Address: common.FlowAddress(flow.HexToAddress("0x2")),
+	}
 
 	d := Distribution{
 		DistID: common.FlowID(1),
 		Issuer: common.FlowAddress(flow.HexToAddress("0x1")),
 		PackTemplate: PackTemplate{
+			PackReference: common.AddressLocation{
+				Name:    "TestPackNFT",
+				Address: common.FlowAddress(flow.HexToAddress("0x2")),
+			},
 			PackCount: uint(packCount),
 			Buckets: []Bucket{
 				{
+					CollectibleReference:  collectibleRef,
 					CollectibleCount:      2,
 					CollectibleCollection: bucket1,
 				},
 				{
+					CollectibleReference:  collectibleRef,
 					CollectibleCount:      3,
 					CollectibleCollection: bucket2,
 				},
-			},
-			PackReference: AddressLocation{
-				Name:    "TestPackNFT",
-				Address: common.FlowAddress(flow.HexToAddress("0x2")),
-			},
-			CollectibleReference: AddressLocation{
-				Name:    "TestCollectibleNFT",
-				Address: common.FlowAddress(flow.HexToAddress("0x2")),
 			},
 		},
 	}
@@ -97,12 +109,12 @@ func TestDistributionResolution(t *testing.T) {
 
 	for _, p := range d.Packs {
 		expected := d.PackSlotCount()
-		if len(p.Slots) != expected {
+		if len(p.Collectibles) != expected {
 			t.Fatalf("expected there to be %d slots", expected)
 		}
 
-		for _, s := range p.Slots {
-			if s == common.FlowID(0) {
+		for _, c := range p.Collectibles {
+			if c.FlowId == common.FlowID(0) {
 				t.Fatalf("did not expect 0 value in a slot")
 			}
 		}

--- a/service/app/pack.go
+++ b/service/app/pack.go
@@ -1,27 +1,62 @@
 package app
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/flow-hydraulics/flow-pds/service/common"
 )
 
-// Seal should
+const SALT_LENGTH = 8
+const HASH_DELIM = ","
+
+// SetCommitmentHash should
 // - validate the pack
 // - decide on a random salt value
 // - calculate the commitment hash for the pack
-// - set the pack as sealed
-func (p *Pack) Seal() error {
-	if p.State != common.PackStateInit {
-		return fmt.Errorf("pack in unexpected state: %d", p.State)
+func (p *Pack) SetCommitmentHash(dist *Distribution) error {
+	if !p.Salt.IsEmpty() {
+		return fmt.Errorf("salt is already set")
+	}
+
+	if !p.CommitmentHash.IsEmpty() {
+		return fmt.Errorf("commitmentHash is already set")
 	}
 
 	if err := p.Validate(); err != nil {
 		return fmt.Errorf("pack validation error: %w", err)
 	}
 
-	p.Salt = "TODO"
-	p.CommitmentHash = "TODO"
+	salt, err := common.GenerateRandomBytes(SALT_LENGTH)
+	if err != nil {
+		return err
+	}
+
+	p.Salt = salt
+	p.CommitmentHash = p.Hash(dist.PackTemplate.CollectibleReference)
+
+	return nil
+}
+
+func (p *Pack) Hash(collectibleRef AddressLocation) []byte {
+	inputs := make([]string, 1+len(p.Slots))
+	inputs[0] = hex.EncodeToString(p.Salt)
+	for i, s := range p.Slots {
+		inputs[i+1] = fmt.Sprintf("%s:%d", collectibleRef, s)
+	}
+	h := sha256.Sum256([]byte(strings.Join(inputs, HASH_DELIM)))
+	return h[:]
+}
+
+// Seal should
+// - set the pack as sealed
+func (p *Pack) Seal() error {
+	if p.State != common.PackStateInit {
+		return fmt.Errorf("pack in unexpected state: %d", p.State)
+	}
+
 	p.State = common.PackStateSealed
 
 	return nil

--- a/service/app/pack.go
+++ b/service/app/pack.go
@@ -16,7 +16,7 @@ const HASH_DELIM = ","
 // - validate the pack
 // - decide on a random salt value
 // - calculate the commitment hash for the pack
-func (p *Pack) SetCommitmentHash(dist *Distribution) error {
+func (p *Pack) SetCommitmentHash() error {
 	if !p.Salt.IsEmpty() {
 		return fmt.Errorf("salt is already set")
 	}
@@ -35,16 +35,16 @@ func (p *Pack) SetCommitmentHash(dist *Distribution) error {
 	}
 
 	p.Salt = salt
-	p.CommitmentHash = p.Hash(dist.PackTemplate.CollectibleReference)
+	p.CommitmentHash = p.Hash()
 
 	return nil
 }
 
-func (p *Pack) Hash(collectibleRef AddressLocation) []byte {
-	inputs := make([]string, 1+len(p.Slots))
+func (p *Pack) Hash() []byte {
+	inputs := make([]string, 1+len(p.Collectibles))
 	inputs[0] = hex.EncodeToString(p.Salt)
-	for i, s := range p.Slots {
-		inputs[i+1] = fmt.Sprintf("%s:%d", collectibleRef, s)
+	for i, c := range p.Collectibles {
+		inputs[i+1] = c.String()
 	}
 	h := sha256.Sum256([]byte(strings.Join(inputs, HASH_DELIM)))
 	return h[:]

--- a/service/app/store_gorm.go
+++ b/service/app/store_gorm.go
@@ -11,7 +11,7 @@ type GormStore struct {
 }
 
 func NewGormStore(db *gorm.DB) *GormStore {
-	db.AutoMigrate(&Distribution{}, &Bucket{}, &Pack{}, &PackSlot{})
+	db.AutoMigrate(&Distribution{}, &Bucket{}, &Pack{})
 	return &GormStore{db}
 }
 
@@ -46,7 +46,7 @@ func (s *GormStore) ListDistributions(opt ListOptions) ([]Distribution, error) {
 // Get distribution
 func (s *GormStore) GetDistribution(id uuid.UUID) (*Distribution, error) {
 	distribution := Distribution{}
-	if err := s.db.Preload("Packs.Slots").Preload(clause.Associations).First(&distribution, id).Error; err != nil {
+	if err := s.db.Preload(clause.Associations).First(&distribution, id).Error; err != nil {
 		return nil, err
 	}
 	return &distribution, nil

--- a/service/app/store_gorm.go
+++ b/service/app/store_gorm.go
@@ -11,7 +11,7 @@ type GormStore struct {
 }
 
 func NewGormStore(db *gorm.DB) *GormStore {
-	db.AutoMigrate(&Distribution{}, &Bucket{}, &Pack{})
+	db.AutoMigrate(&Distribution{}, &Bucket{}, &Pack{}, &Collectible{})
 	return &GormStore{db}
 }
 
@@ -46,7 +46,7 @@ func (s *GormStore) ListDistributions(opt ListOptions) ([]Distribution, error) {
 // Get distribution
 func (s *GormStore) GetDistribution(id uuid.UUID) (*Distribution, error) {
 	distribution := Distribution{}
-	if err := s.db.Preload(clause.Associations).First(&distribution, id).Error; err != nil {
+	if err := s.db.Preload("Packs.Collectibles").Preload(clause.Associations).First(&distribution, id).Error; err != nil {
 		return nil, err
 	}
 	return &distribution, nil

--- a/service/app/types.go
+++ b/service/app/types.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/flow-hydraulics/flow-pds/service/common"
@@ -51,11 +52,11 @@ type Pack struct {
 	DistributionID uuid.UUID
 	ID             uuid.UUID `gorm:"column:id;primary_key;type:uuid;"`
 
-	FlowID         common.FlowID             `gorm:"column:flow_id;index"`         // ID of the Pack NFT
-	State          common.PackState          `gorm:"column:state"`                 // public
-	Salt           common.PackSalt           `gorm:"column:salt"`                  // private
-	CommitmentHash common.PackCommitmentHash `gorm:"column:commitment_hash;index"` // public
-	Slots          common.FlowIDList         // private
+	FlowID         common.FlowID      `gorm:"column:flow_id;index"`         // ID of the Pack NFT
+	State          common.PackState   `gorm:"column:state"`                 // public
+	Salt           common.BinaryValue `gorm:"column:salt"`                  // private
+	CommitmentHash common.BinaryValue `gorm:"column:commitment_hash;index"` // public
+	Slots          common.FlowIDList  // private
 }
 
 // AddressLocation is a reference to a contract on flow chain
@@ -89,4 +90,8 @@ func (Pack) TableName() string {
 func (p *Pack) BeforeCreate(tx *gorm.DB) (err error) {
 	p.ID = uuid.New()
 	return nil
+}
+
+func (al AddressLocation) String() string {
+	return fmt.Sprintf("A.%s.%s", al.Address, al.Name)
 }

--- a/service/app/types.go
+++ b/service/app/types.go
@@ -106,8 +106,8 @@ func (Collectible) TableName() string {
 	return "distribution_collectibles"
 }
 
-func (p *Collectible) BeforeCreate(tx *gorm.DB) (err error) {
-	p.ID = uuid.New()
+func (c *Collectible) BeforeCreate(tx *gorm.DB) (err error) {
+	c.ID = uuid.New()
 	return nil
 }
 

--- a/service/app/types.go
+++ b/service/app/types.go
@@ -55,16 +55,7 @@ type Pack struct {
 	State          common.PackState          `gorm:"column:state"`                 // public
 	Salt           common.PackSalt           `gorm:"column:salt"`                  // private
 	CommitmentHash common.PackCommitmentHash `gorm:"column:commitment_hash;index"` // public
-	Slots          []PackSlot                // private
-}
-
-type PackSlot struct {
-	gorm.Model
-	PackID uuid.UUID
-	ID     uuid.UUID `gorm:"column:id;primary_key;type:uuid;"`
-
-	State             common.PackSlotState `gorm:"column:state"`
-	CollectibleFlowID common.FlowID        `gorm:"column:collectible_flow_id"`
+	Slots          common.FlowIDList         // private
 }
 
 // AddressLocation is a reference to a contract on flow chain
@@ -97,14 +88,5 @@ func (Pack) TableName() string {
 
 func (p *Pack) BeforeCreate(tx *gorm.DB) (err error) {
 	p.ID = uuid.New()
-	return nil
-}
-
-func (PackSlot) TableName() string {
-	return "distribution_packslots"
-}
-
-func (ps *PackSlot) BeforeCreate(tx *gorm.DB) (err error) {
-	ps.ID = uuid.New()
 	return nil
 }

--- a/service/app/types.go
+++ b/service/app/types.go
@@ -64,9 +64,16 @@ type Collectible struct {
 	PackID uuid.UUID
 	ID     uuid.UUID `gorm:"column:id;primary_key;type:uuid;"`
 
-	FlowId            common.FlowID          `gorm:"column:flow_id"`                        // ID of the collectible NFT
+	FlowID            common.FlowID          `gorm:"column:flow_id"`                        // ID of the collectible NFT
 	ContractReference common.AddressLocation `gorm:"embedded;embeddedPrefix:contract_ref_"` // Reference to the collectible NFT contract
 }
+
+// Implement sort.Interface by FlowID for Collectible slice
+type CollectibleByFlowID []Collectible
+
+func (c CollectibleByFlowID) Len() int           { return len(c) }
+func (c CollectibleByFlowID) Less(i, j int) bool { return c[i].FlowID < c[j].FlowID }
+func (c CollectibleByFlowID) Swap(i, j int)      { c[i], c[j] = c[j], c[i] }
 
 func (Distribution) TableName() string {
 	return "distributions"
@@ -105,5 +112,5 @@ func (p *Collectible) BeforeCreate(tx *gorm.DB) (err error) {
 }
 
 func (c Collectible) String() string {
-	return fmt.Sprintf("%s.%d", c.ContractReference, c.FlowId)
+	return fmt.Sprintf("%s.%d", c.ContractReference, c.FlowID)
 }

--- a/service/app/validation.go
+++ b/service/app/validation.go
@@ -84,7 +84,7 @@ func (p Pack) Validate() error {
 	}
 
 	for i, slot := range p.Slots {
-		if slot.CollectibleFlowID == common.FlowID(cadence.NewUInt64(0)) {
+		if slot == common.FlowID(cadence.NewUInt64(0)) {
 			return fmt.Errorf("uninitialized collectible in slot %d", i+1)
 		}
 	}

--- a/service/app/validation.go
+++ b/service/app/validation.go
@@ -107,7 +107,7 @@ func (c Collectible) Validate() error {
 		return fmt.Errorf("error while validating ContractReference: %w", err)
 	}
 
-	if c.FlowId == common.FlowID(0) {
+	if c.FlowID == common.FlowID(0) {
 		return fmt.Errorf("uninitialized flowID")
 	}
 

--- a/service/app/validation.go
+++ b/service/app/validation.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 
 	"github.com/flow-hydraulics/flow-pds/service/common"
-	"github.com/onflow/cadence"
 	"github.com/onflow/flow-go-sdk"
 )
 
@@ -37,10 +36,6 @@ func (pt PackTemplate) Validate() error {
 		return fmt.Errorf("error while validating PackReference: %w", err)
 	}
 
-	if err := ValidateContractReference(pt.CollectibleReference); err != nil {
-		return fmt.Errorf("error while validating CollectibleReference: %w", err)
-	}
-
 	for i, bucket := range pt.Buckets {
 		if err := bucket.Validate(); err != nil {
 			return fmt.Errorf("error in slot template %d: %w", i+1, err)
@@ -64,6 +59,10 @@ func (bucket Bucket) Validate() error {
 		return fmt.Errorf("collectible count can not be zero")
 	}
 
+	if err := ValidateContractReference(bucket.CollectibleReference); err != nil {
+		return fmt.Errorf("error while validating CollectibleReference: %w", err)
+	}
+
 	if len(bucket.CollectibleCollection) == 0 {
 		return fmt.Errorf("empty collection")
 	}
@@ -79,25 +78,38 @@ func (bucket Bucket) Validate() error {
 }
 
 func (p Pack) Validate() error {
-	if len(p.Slots) == 0 {
+	if len(p.Collectibles) == 0 {
 		return fmt.Errorf("no slots")
 	}
 
-	for i, slot := range p.Slots {
-		if slot == common.FlowID(cadence.NewUInt64(0)) {
-			return fmt.Errorf("uninitialized collectible in slot %d", i+1)
+	for i, c := range p.Collectibles {
+		err := c.Validate()
+		if err != nil {
+			return fmt.Errorf("error while validating collectible in slot #%d: %w", i+1, err)
 		}
 	}
 
 	return nil
 }
 
-func ValidateContractReference(ref AddressLocation) error {
+func ValidateContractReference(ref common.AddressLocation) error {
 	if ref.Name == "" {
 		return fmt.Errorf("empty name")
 	}
 	if flow.Address(ref.Address) == flow.EmptyAddress {
 		return fmt.Errorf("empty address")
 	}
+	return nil
+}
+
+func (c Collectible) Validate() error {
+	if err := ValidateContractReference(c.ContractReference); err != nil {
+		return fmt.Errorf("error while validating ContractReference: %w", err)
+	}
+
+	if c.FlowId == common.FlowID(0) {
+		return fmt.Errorf("uninitialized flowID")
+	}
+
 	return nil
 }

--- a/service/common/address.go
+++ b/service/common/address.go
@@ -9,6 +9,10 @@ import (
 
 type FlowAddress flow.Address
 
+func (a FlowAddress) String() string {
+	return flow.Address(a).String()
+}
+
 func (a FlowAddress) MarshalJSON() ([]byte, error) {
 	return flow.Address(a).MarshalJSON()
 }

--- a/service/common/address.go
+++ b/service/common/address.go
@@ -20,19 +20,15 @@ func (a *FlowAddress) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-func (FlowAddress) GormDataType() string {
-	return "text"
+func (a FlowAddress) Value() (driver.Value, error) {
+	return flow.Address(a).Bytes(), nil
 }
 
 func (a *FlowAddress) Scan(value interface{}) error {
-	str, ok := value.(string)
+	bytes, ok := value.([]byte)
 	if !ok {
 		return fmt.Errorf("failed to unmarshal FlowAddress value: %v", value)
 	}
-	*a = FlowAddress(flow.HexToAddress(str))
+	*a = FlowAddress(flow.BytesToAddress(bytes))
 	return nil
-}
-
-func (a FlowAddress) Value() (driver.Value, error) {
-	return flow.Address(a).Hex(), nil
 }

--- a/service/common/address.go
+++ b/service/common/address.go
@@ -9,6 +9,12 @@ import (
 
 type FlowAddress flow.Address
 
+// AddressLocation is a reference to a contract on chain.
+type AddressLocation struct {
+	Name    string      `json:"name" gorm:"column:name"`
+	Address FlowAddress `json:"address" gorm:"column:address"`
+}
+
 func (a FlowAddress) String() string {
 	return flow.Address(a).String()
 }
@@ -35,4 +41,8 @@ func (a *FlowAddress) Scan(value interface{}) error {
 	}
 	*a = FlowAddress(flow.BytesToAddress(bytes))
 	return nil
+}
+
+func (al AddressLocation) String() string {
+	return fmt.Sprintf("A.%s.%s", al.Address, al.Name)
 }

--- a/service/common/binary.go
+++ b/service/common/binary.go
@@ -1,0 +1,21 @@
+package common
+
+import (
+	"database/sql/driver"
+	"encoding/hex"
+	"fmt"
+)
+
+type BinaryValue []byte
+
+func (b BinaryValue) IsEmpty() bool {
+	return len(b) == 0
+}
+
+func (b BinaryValue) Value() (driver.Value, error) {
+	return []byte(b), nil
+}
+
+func (b BinaryValue) MarshalJSON() ([]byte, error) {
+	return []byte(fmt.Sprintf("\"%s\"", hex.EncodeToString(b))), nil
+}

--- a/service/common/common.go
+++ b/service/common/common.go
@@ -1,4 +1,15 @@
 package common
 
-type PackSalt string
-type PackCommitmentHash string
+import (
+	"crypto/rand"
+)
+
+func GenerateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	if err != nil {
+		return nil, err
+	}
+
+	return b, nil
+}

--- a/service/common/flowID.go
+++ b/service/common/flowID.go
@@ -9,10 +9,14 @@ import (
 	"github.com/onflow/cadence"
 )
 
-const delim = ","
+const FLOW_ID_LIST_SCAN_DELIM = ","
 
 type FlowID cadence.UInt64
 type FlowIDList []FlowID
+
+func (id FlowID) Bytes() []byte {
+	return cadence.UInt64(id).ToBigEndianBytes()
+}
 
 func FlowIDFromInt64(i int64) FlowID {
 	return FlowID(cadence.NewUInt64(uint64(i)))
@@ -35,7 +39,7 @@ func (l *FlowIDList) Scan(value interface{}) error {
 	if !ok {
 		return fmt.Errorf("failed to unmarshal FlowIDList value: %v", value)
 	}
-	strSplit := strings.Split(string(str), delim)
+	strSplit := strings.Split(string(str), FLOW_ID_LIST_SCAN_DELIM)
 	list := make([]FlowID, len(strSplit))
 	for i, s := range strSplit {
 		id, err := FlowIDFromStr(s)
@@ -49,5 +53,5 @@ func (l *FlowIDList) Scan(value interface{}) error {
 }
 
 func (l FlowIDList) Value() (driver.Value, error) {
-	return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(l)), delim), "[]"), nil
+	return strings.Trim(strings.Join(strings.Fields(fmt.Sprint(l)), FLOW_ID_LIST_SCAN_DELIM), "[]"), nil
 }

--- a/service/common/states.go
+++ b/service/common/states.go
@@ -2,7 +2,6 @@ package common
 
 type DistributionState uint
 type PackState uint
-type PackSlotState uint
 
 const (
 	DistributionStateInit DistributionState = iota
@@ -19,11 +18,4 @@ const (
 	PackStateSealed
 	PackStateRevealed
 	PackStateEmpty
-)
-
-const (
-	PackSlotStateInit PackSlotState = iota
-	PackSlotStateInTransit
-	PackSlotStateInStorage
-	PackSlotStateEmtpy
 )

--- a/service/http/handlers.go
+++ b/service/http/handlers.go
@@ -35,6 +35,7 @@ func HandleCreateDistribution(logger *log.Logger, app *app.App) http.HandlerFunc
 			return
 		}
 
+		// TODO (latenssi): respond with the distribution instead of ID
 		res := ResCreateDistribution{DistributionId: id}
 
 		handleJsonResponse(rw, http.StatusCreated, res)

--- a/service/http/handlers.go
+++ b/service/http/handlers.go
@@ -60,9 +60,9 @@ func HandleListDistributions(logger *log.Logger, app *app.App) http.HandlerFunc 
 			return
 		}
 
-		res := make([]ReqDistributionListItem, len(list))
+		res := make([]ResDistributionListItem, len(list))
 		for i := range res {
-			res[i] = ReqDistributionListItemFromApp(list[i])
+			res[i] = ResDistributionListItemFromApp(list[i])
 		}
 
 		handleJsonResponse(rw, http.StatusOK, res)
@@ -86,7 +86,7 @@ func HandleGetDistribution(logger *log.Logger, app *app.App) http.HandlerFunc {
 			return
 		}
 
-		res := ReqDistributionFromApp(*dist)
+		res := ResDistributionFromApp(*dist)
 
 		handleJsonResponse(rw, http.StatusOK, res)
 	}

--- a/service/http/types.go
+++ b/service/http/types.go
@@ -65,9 +65,9 @@ type Bucket struct {
 }
 
 type Pack struct {
-	FlowID         common.FlowID             `json:"flowID"`
-	State          common.PackState          `json:"state"`
-	CommitmentHash common.PackCommitmentHash `json:"commitmentHash"`
+	FlowID         common.FlowID      `json:"flowID"`
+	State          common.PackState   `json:"state"`
+	CommitmentHash common.BinaryValue `json:"commitmentHash"`
 }
 
 type AddressLocation struct {

--- a/service/http/types.go
+++ b/service/http/types.go
@@ -19,7 +19,7 @@ type ReqCreateDistribution struct {
 	PackTemplate PackTemplate         `json:"packTemplate"`
 }
 
-type ReqDistribution struct {
+type ResDistribution struct {
 	ID                 uuid.UUID                `json:"id"`
 	CreatedAt          time.Time                `json:"createdAt"`
 	UpdatedAt          time.Time                `json:"updatedAt"`
@@ -33,7 +33,7 @@ type ReqDistribution struct {
 	SettlementStatus   SettlementStatus         `json:"settlementStatuts"`
 }
 
-type ReqDistributionListItem struct {
+type ResDistributionListItem struct {
 	ID           uuid.UUID                `json:"id"`
 	CreatedAt    time.Time                `json:"createdAt"`
 	UpdatedAt    time.Time                `json:"updatedAt"`
@@ -80,8 +80,8 @@ type SettlementStatus struct {
 	Total   uint `json:"total"`
 }
 
-func ReqDistributionFromApp(d app.Distribution) ReqDistribution {
-	return ReqDistribution{
+func ResDistributionFromApp(d app.Distribution) ResDistribution {
+	return ResDistribution{
 		ID:                 d.ID,
 		CreatedAt:          d.CreatedAt,
 		UpdatedAt:          d.UpdatedAt,
@@ -95,8 +95,8 @@ func ReqDistributionFromApp(d app.Distribution) ReqDistribution {
 	}
 }
 
-func ReqDistributionListItemFromApp(d app.Distribution) ReqDistributionListItem {
-	return ReqDistributionListItem{
+func ResDistributionListItemFromApp(d app.Distribution) ResDistributionListItem {
+	return ResDistributionListItem{
 		ID:           d.ID,
 		CreatedAt:    d.CreatedAt,
 		UpdatedAt:    d.UpdatedAt,

--- a/service/http/types.go
+++ b/service/http/types.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ResCreateDistribution struct {
-	DistributionId string `json:"distributionId"`
+	DistributionId uuid.UUID `json:"distributionId"`
 }
 
 type ReqCreateDistribution struct {


### PR DESCRIPTION
New features:
- Move CollectibleReference from PackTemplate to Bucket (allowing different types of collectibles in a Pack)
- First implementation of pack hashing
- Make `resolvedCollection` more compact in http response
- Instead of shuffling resolved collection, sort it by FlowID
- Change Slot to Collectible in Packs

Chores:
- Use uuid instead of string in app <> http interface
- Fix naming conventions in http types
- Store addresses as byte arrays
