### PR TITLE
feat: reveal-and-open with double tx same script

### DIFF
--- a/cadence-transactions/pds/reveal_packNFT.cdc
+++ b/cadence-transactions/pds/reveal_packNFT.cdc
@@ -1,17 +1,34 @@
 import PDS from 0x{{.PDS}}
+import PackNFT from 0x{{.PackNFT}}
 import ExampleNFT from 0x{{.ExampleNFT}}
+import NonFungibleToken from 0x{{.NonFungibleToken}}
 
-transaction (distId: UInt64, packId: UInt64, nftContractAddrs: [Address], nftContractName: [String], nftIds: [UInt64], salt: String) {
+transaction (distId: UInt64, packId: UInt64, nftContractAddrs: [Address], nftContractName: [String], nftIds: [UInt64], salt: String, recvAddr: Address?) {
     prepare(pds: AuthAccount) {
         let cap = pds.borrow<&PDS.DistributionManager>(from: PDS.distManagerStoragePath) ?? panic("pds does not have Dist manager")
-        //  revealPackNFT(packId: UInt64, nftContractAddrs: [Address], nftContractName: [String], nftIds: [UInt64], salt: String) {
-        cap.revealPackNFT(
-            distId: distId, 
-            packId: packId, 
-            nftContractAddrs: nftContractAddrs, 
-            nftContractName: nftContractName, 
-            nftIds: nftIds, 
-            salt: salt)
+        let p = PackNFT.borrowPackRepresentation(id: packId) ?? panic ("No such pack")
+        if recvAddr != nil && p.status == PackNFT.Status.Revealed {
+            let recvAcct = getAccount(recvAddr!)
+            let recv = recvAcct.getCapability(ExampleNFT.CollectionPublicPath).borrow<&{NonFungibleToken.CollectionPublic}>()
+                ?? panic("Unable to borrow Collection Public reference for recipient")
+            cap.openPackNFT(
+                distId: distId,
+                packId: packId, 
+                nftContractAddrs: nftContractAddrs, 
+                nftContractName: nftContractName, 
+                nftIds: nftIds, 
+                recvCap: recv, 
+                collectionProviderPath: ExampleNFT.CollectionProviderPrivPath, 
+            )
+        } else {
+            cap.revealPackNFT(
+                    distId: distId, 
+                    packId: packId, 
+                    nftContractAddrs: nftContractAddrs, 
+                    nftContractName: nftContractName, 
+                    nftIds: nftIds, 
+                    salt: salt)
+        }
     }
 }
 

--- a/go-contracts/pds/pds.go
+++ b/go-contracts/pds/pds.go
@@ -185,10 +185,18 @@ func PDSRevealPackNFT(
 	nftContractNames cadence.Value,
 	nftIds cadence.Value,
 	salt string,
+	receiver string,
 	account string,
 ) (events []*gwtf.FormatedEvent, err error) {
 	txScript := "../cadence-transactions/pds/reveal_packNFT.cdc"
 	code := util.ParseCadenceTemplate(txScript)
+	var recv cadence.Value
+	if len(receiver) != 0 {
+		addr := g.Account(receiver).Address()
+		recv = cadence.NewAddress(addr)
+	} else {
+		recv = nil
+	}
 	e, err := g.
 		TransactionFromFile(txScript, code).
 		SignProposeAndPayAs("pds").
@@ -198,6 +206,7 @@ func PDSRevealPackNFT(
 		Argument(nftContractNames).
 		Argument(nftIds).
 		StringArgument(salt).
+		Argument(cadence.NewOptional(recv)).
 		RunE()
 	events = util.ParseTestEvents(e)
 	return

--- a/service/app/contract_interface.go
+++ b/service/app/contract_interface.go
@@ -705,6 +705,12 @@ func (c *Contract) UpdateCirculatingPack(ctx context.Context, db *gorm.DB, cpc *
 						return err
 					}
 
+					// Get the owner of the pack from the transaction that emitted the open request event
+					tx, err := c.flowClient.GetTransaction(ctx, e.TransactionID)
+					if err != nil {
+						return err
+					}
+					owner := tx.Authorizers[0]
 					collectibleCount := len(pack.Collectibles)
 
 					collectibleContractAddresses := make([]cadence.Value, collectibleCount)
@@ -724,6 +730,7 @@ func (c *Contract) UpdateCirculatingPack(ctx context.Context, db *gorm.DB, cpc *
 						cadence.NewArray(collectibleContractNames),
 						cadence.NewArray(collectibleIDs),
 						cadence.String(pack.Salt.String()),
+                        cadence.NewOptional(cadence.Address(owner)),
 					}
 
 					txScript := util.ParseCadenceTemplate(REVEAL_SCRIPT)


### PR DESCRIPTION
The same tx script handles both reveal and open (if the conditions are met). 
This allows for the backend to send in the same tx twice using the same script and potentially have them execute in the same block. 