### PR TITLE
Refactor some problematic bits found during scalability tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,6 +19,8 @@ __debug_bin
 .vscode
 tmp/
 *.log
+flowdb/
+*.pid
 
 flow.json
 Dockerfile

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,23 @@
-.env
-.local*
-.env.*
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+.env*
+!.env.example
 *.db
+*.db-journal
+__debug_bin
+.vscode
+tmp/
 *.log
+flowdb/
+*.pid

--- a/cadence-scripts/collectibleNFT/balance.cdc
+++ b/cadence-scripts/collectibleNFT/balance.cdc
@@ -1,0 +1,10 @@
+import NonFungibleToken from 0x{{.NonFungibleToken}}
+import {{.CollectibleNFTName}} from 0x{{.CollectibleNFTAddress}}
+
+pub fun main(account: Address): Int {
+    let receiver = getAccount(account)
+        .getCapability({{.CollectibleNFTName}}.CollectionPublicPath)!
+        .borrow<&{NonFungibleToken.CollectionPublic}>()!
+
+    return receiver.getIDs().length
+}

--- a/cadence-scripts/collectibleNFT/balance_ids.cdc
+++ b/cadence-scripts/collectibleNFT/balance_ids.cdc
@@ -1,0 +1,20 @@
+import NonFungibleToken from 0x{{.NonFungibleToken}}
+import {{.CollectibleNFTName}} from 0x{{.CollectibleNFTAddress}}
+
+pub fun main(account: Address, offset: UInt64, limit: UInt64): [UInt64] {
+    let receiver = getAccount(account)
+        .getCapability({{.CollectibleNFTName}}.CollectionPublicPath)!
+        .borrow<&{NonFungibleToken.CollectionPublic}>()!
+
+    let ids = receiver.getIDs()
+    let idsLen = UInt64(ids.length)
+
+    var res: [UInt64] = []
+    var i = offset
+    while i < offset+limit && i < idsLen {
+        res.append(ids[i])
+        i = i + 1
+    }
+
+    return res
+}

--- a/cadence-transactions/collectibleNFT/mint.cdc
+++ b/cadence-transactions/collectibleNFT/mint.cdc
@@ -1,0 +1,26 @@
+import NonFungibleToken from 0x{{.NonFungibleToken}}
+import {{.CollectibleNFTName}} from 0x{{.CollectibleNFTAddress}}
+
+// Used for testing purposes
+
+transaction(recipient: Address, batchSize: Int) {
+
+    let minter: &{{.CollectibleNFTName}}.NFTMinter
+
+    prepare(signer: AuthAccount) {
+        self.minter = signer
+            .borrow<&{{.CollectibleNFTName}}.NFTMinter>(from: {{.CollectibleNFTName}}.MinterStoragePath)!
+    }
+
+    execute {
+        let receiver = getAccount(recipient)
+            .getCapability({{.CollectibleNFTName}}.CollectionPublicPath)!
+            .borrow<&{NonFungibleToken.CollectionPublic}>()!
+
+        var i = 0
+        while i < batchSize {
+            self.minter.mintNFT(recipient: receiver)
+            i = i + 1
+        }
+    }
+}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,24 @@ const version = "0.1.0"
 var (
 	sha1ver   string // sha1 revision used to build the program
 	buildTime string // when the executable was built
+	logger    *log.Logger
 )
+
+func init() {
+	lvl, ok := os.LookupEnv("FLOW_PDS_LOG_LEVEL")
+	if !ok {
+		// LOG_LEVEL not set, default to info
+		lvl = "info"
+	}
+
+	ll, err := log.ParseLevel(lvl)
+	if err != nil {
+		ll = log.DebugLevel
+	}
+
+	logger = log.New()
+	logger.SetLevel(ll)
+}
 
 func main() {
 	var (
@@ -60,9 +77,6 @@ func runServer(cfg *config.Config) error {
 	if cfg == nil {
 		return fmt.Errorf("config not provided")
 	}
-
-	logger := log.New()
-	logger.SetLevel(log.InfoLevel)
 
 	logger.Printf("Starting server (v%s)...\n", version)
 

--- a/service/app/contract_service.go
+++ b/service/app/contract_service.go
@@ -284,7 +284,7 @@ func (svc *ContractService) StartSettlement(ctx context.Context, db *gorm.DB, di
 			begin := batchIndex * SETTLE_BATCH_SIZE
 			end := minInt((batchIndex+1)*SETTLE_BATCH_SIZE, len(collectibles))
 
-			if begin > end {
+			if begin >= end {
 				break
 			}
 
@@ -432,7 +432,7 @@ func (svc *ContractService) StartMinting(ctx context.Context, db *gorm.DB, dist 
 		begin := batchIndex * MINT_BATCH_SIZE
 		end := minInt((batchIndex+1)*MINT_BATCH_SIZE, len(packs))
 
-		if begin > end {
+		if begin >= end {
 			break
 		}
 

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -37,7 +37,7 @@ type Config struct {
 
 	// -- Testing --
 
-	TestNOCollectibles int `env:"TEST_COLLECTIBLES" envDefault:"20"`
+	TestPackCount int `env:"TEST_PACK_COUNT" envDefault:"4"`
 }
 
 type ConfigOptions struct {

--- a/service/flow_helpers/cadence.go
+++ b/service/flow_helpers/cadence.go
@@ -10,9 +10,9 @@ import (
 )
 
 type CadenceTemplateVars struct {
-	PDS                   string `env:"PDS_ADDRESS,notEmpty"`
-	IPackNFT              string `env:"PDS_ADDRESS,notEmpty"`
-	NonFungibleToken      string `env:"NON_FUNGIBLE_TOKEN_ADDRESS,notEmpty"`
+	PDS                   string `env:"PDS_ADDRESS"`
+	IPackNFT              string `env:"PDS_ADDRESS"`
+	NonFungibleToken      string `env:"NON_FUNGIBLE_TOKEN_ADDRESS"`
 	PackNFTName           string
 	PackNFTAddress        string
 	CollectibleNFTName    string

--- a/test-e2e-large.sh
+++ b/test-e2e-large.sh
@@ -1,4 +1,4 @@
 #/bin/bash
 
 go clean -testcache
-TEST_COLLECTIBLES=1000 go test -timeout 180m -v -run ^TestE2E$ .
+TEST_PACK_COUNT=100 go test -timeout 24h -v -run ^TestE2E$ .


### PR DESCRIPTION
- Fix batch count
- Add limit for how many transactions are sent per poller run
- Change test config to allow setting pack count instead of collectible count
- Allow setting log level via env var `FLOW_PDS_LOG_LEVEL`
- Add helpers functions to get NFT balance and ID lists when balance is big