### PR TITLE
Make gas limit and batch sizes configurable

### DIFF
--- a/service/app/contract_service.go
+++ b/service/app/contract_service.go
@@ -96,6 +96,7 @@ func (svc *ContractService) SetDistCap(ctx context.Context, db *gorm.DB, issuer 
 
 	tx := flow.NewTransaction().
 		SetScript(txScript).
+		SetGasLimit(svc.cfg.TransactionGasLimit).
 		SetReferenceBlockID(latestBlockHeader.ID)
 
 	tx.AddArgument(cadence.Address(issuer))
@@ -173,6 +174,7 @@ func (svc *ContractService) SetupDistribution(ctx context.Context, db *gorm.DB, 
 
 		tx := flow.NewTransaction().
 			SetScript(txScript).
+			SetGasLimit(svc.cfg.TransactionGasLimit).
 			SetReferenceBlockID(latestBlockHeader.ID)
 
 		tx.AddArgument(cadence.Path{Domain: "private", Identifier: contract.ProviderPath()})

--- a/service/app/contract_service.go
+++ b/service/app/contract_service.go
@@ -26,12 +26,6 @@ const (
 	OPENED         = "Opened"
 )
 
-// Going much above these will cause the transactions to use more than 9999 gas
-const (
-	SETTLE_BATCH_SIZE = 40
-	MINT_BATCH_SIZE   = 40
-)
-
 const (
 	SET_DIST_CAP_SCRIPT     = "./cadence-transactions/pds/set_pack_issuer_cap.cdc"
 	SETUP_COLLECTION_SCRIPT = "./cadence-transactions/collectibleNFT/setup_collection_and_link_provider.cdc"
@@ -277,10 +271,12 @@ func (svc *ContractService) StartSettlement(ctx context.Context, db *gorm.DB, di
 			return err // rollback
 		}
 
+		batchSize := svc.cfg.SettlementBatchSize
 		batchIndex := 0
+
 		for {
-			begin := batchIndex * SETTLE_BATCH_SIZE
-			end := minInt((batchIndex+1)*SETTLE_BATCH_SIZE, len(collectibles))
+			begin := batchIndex * batchSize
+			end := minInt((batchIndex+1)*batchSize, len(collectibles))
 
 			if begin >= end {
 				break
@@ -425,10 +421,12 @@ func (svc *ContractService) StartMinting(ctx context.Context, db *gorm.DB, dist 
 		return err // rollback
 	}
 
+	batchSize := svc.cfg.MintingBatchSize
 	batchIndex := 0
+
 	for {
-		begin := batchIndex * MINT_BATCH_SIZE
-		end := minInt((batchIndex+1)*MINT_BATCH_SIZE, len(packs))
+		begin := batchIndex * batchSize
+		end := minInt((batchIndex+1)*batchSize, len(packs))
 
 		if begin >= end {
 			break

--- a/service/app/contract_service.go
+++ b/service/app/contract_service.go
@@ -102,7 +102,6 @@ func (svc *ContractService) SetDistCap(ctx context.Context, db *gorm.DB, issuer 
 
 	tx := flow.NewTransaction().
 		SetScript(txScript).
-		SetGasLimit(9999).
 		SetReferenceBlockID(latestBlockHeader.ID)
 
 	tx.AddArgument(cadence.Address(issuer))
@@ -180,7 +179,6 @@ func (svc *ContractService) SetupDistribution(ctx context.Context, db *gorm.DB, 
 
 		tx := flow.NewTransaction().
 			SetScript(txScript).
-			SetGasLimit(9999).
 			SetReferenceBlockID(latestBlockHeader.ID)
 
 		tx.AddArgument(cadence.Path{Domain: "private", Identifier: contract.ProviderPath()})

--- a/service/app/contract_service.go
+++ b/service/app/contract_service.go
@@ -581,7 +581,7 @@ func (svc *ContractService) UpdateSettlementStatus(ctx context.Context, db *gorm
 			for _, e := range be.Events {
 				eventLogger := logger.WithFields(log.Fields{"eventType": e.Type, "eventID": e.ID()})
 
-				eventLogger.Debug("Handling event")
+				eventLogger.Trace("Handling event")
 
 				evtValueMap := flow_helpers.EventValuesToMap(e)
 
@@ -710,7 +710,7 @@ func (svc *ContractService) UpdateMintingStatus(ctx context.Context, db *gorm.DB
 		for _, e := range be.Events {
 			eventLogger := logger.WithFields(log.Fields{"eventType": e.Type, "eventID": e.ID()})
 
-			eventLogger.Debug("Handling event")
+			eventLogger.Trace("Handling event")
 
 			evtValueMap := flow_helpers.EventValuesToMap(e)
 

--- a/service/app/poller.go
+++ b/service/app/poller.go
@@ -18,7 +18,7 @@ import (
 func poller(app *App) {
 
 	ticker := time.NewTicker(time.Second) // TODO (latenssi): configurable?
-	transactionRatelimiter := ratelimit.New(app.cfg.SendTransactionRate)
+	transactionRatelimiter := ratelimit.New(app.cfg.TransactionSendRate)
 
 	ctx := context.Background()
 	ctx, cancel := context.WithCancel(ctx)
@@ -249,7 +249,7 @@ func handleSendableTransactions(ctx context.Context, db *gorm.DB, contract *Cont
 				"distributionID": t.DistributionID,
 			})
 
-			tx, err := t.Prepare(ctx, contract.flowClient, contract.account)
+			tx, err := t.Prepare(ctx, contract.flowClient, contract.account, contract.cfg.TransactionGasLimit)
 			if err != nil {
 				logger.WithFields(log.Fields{"error": err.Error()}).Warn("Error while preparing transaction")
 				return err

--- a/service/app/poller.go
+++ b/service/app/poller.go
@@ -26,7 +26,7 @@ func poller(app *App) {
 	for {
 		select {
 		case <-ticker.C:
-			app.logger.Debug("Poll start")
+			app.logger.Trace("Poll start")
 
 			logPollerRun("handleResolved", handleResolved(ctx, app.db, app.service), app.logger)
 			logPollerRun("handleSetup", handleSetup(ctx, app.db, app.service), app.logger)
@@ -40,7 +40,7 @@ func poller(app *App) {
 			logPollerRun("handleSentTransactions", handleSentTransactions(ctx, app.db, app.service), app.logger)
 			logPollerRun("handleSendableTransactions", handleSendableTransactions(ctx, app.db, app.service, transactionRatelimiter), app.logger)
 
-			app.logger.Debug("Poll end")
+			app.logger.Trace("Poll end")
 		case <-app.quit:
 			cancel()
 			ticker.Stop()
@@ -65,7 +65,7 @@ func logPollerRun(pollerName string, err error, logger *log.Logger) {
 	} else {
 		logger.WithFields(log.Fields{
 			"pollerName": pollerName,
-		}).Debug("Done")
+		}).Trace("Done")
 	}
 }
 

--- a/service/config/config.go
+++ b/service/config/config.go
@@ -33,7 +33,11 @@ type Config struct {
 	// -- Rates etc. ---
 
 	// How many transactions to send per second at max
-	SendTransactionRate int `env:"FLOW_PDS_SEND_RATE" envDefault:"10"`
+	TransactionSendRate int    `env:"FLOW_PDS_SEND_RATE" envDefault:"10"`
+	TransactionGasLimit uint64 `env:"FLOW_PDS_GAS_LIMIT" envDefault:"9999"`
+	// Going much above 40 will cause the transactions to use more than 9999 gas
+	SettlementBatchSize int `env:"FLOW_PDS_SETTLEMENT_BATCH_SIZE" envDefault:"40"`
+	MintingBatchSize    int `env:"FLOW_PDS_MINTING_BATCH_SIZE" envDefault:"40"`
 
 	// -- Testing --
 

--- a/service/transactions/transactions.go
+++ b/service/transactions/transactions.go
@@ -89,7 +89,7 @@ func (t *StorableTransaction) ArgumentsAsCadence() ([]cadence.Value, error) {
 }
 
 // Prepare parses the transaction into a sendable state.
-func (t *StorableTransaction) Prepare(ctx context.Context, flowClient *client.Client, account *flow_helpers.Account) (*flow.Transaction, error) {
+func (t *StorableTransaction) Prepare(ctx context.Context, flowClient *client.Client, account *flow_helpers.Account, gasLimit uint64) (*flow.Transaction, error) {
 	args, err := t.ArgumentsAsCadence()
 	if err != nil {
 		return nil, err
@@ -97,7 +97,7 @@ func (t *StorableTransaction) Prepare(ctx context.Context, flowClient *client.Cl
 
 	tx := flow.NewTransaction().
 		SetScript([]byte(t.Script)).
-		SetGasLimit(9999)
+		SetGasLimit(gasLimit)
 
 	for _, a := range args {
 		if err := tx.AddArgument(a); err != nil {


### PR DESCRIPTION
- Make gas limit and settlement and mint batch sizes configurable
- Tone down debug logging
- Use default gas limits for basic transactions
- Rename `SendTransactionRate` to `TransactionSendRate`